### PR TITLE
Fix missing import

### DIFF
--- a/hungarian.cpp
+++ b/hungarian.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <deque>
 #include <cassert>
+#include <memory>
 
 #include "hungarian.h"
 


### PR DESCRIPTION
Otherwise, compilation fails because `std::unique_ptr` cannot be found